### PR TITLE
Add support for app export syntax

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ LineChatParser.prototype.process = function (line) {
     var match;
 
     // date header
-    match = line.match(/^(\d{4})\.(\d{2})\.(\d{2}) [A-Z][a-z]+/);
+    match = line.match(/^(\d{4})(?:\.|\/)(\d{2})(?:\.|\/)(\d{2})(?: [A-Z][a-z]+|\(.\))/);
     if (match) {
         var year = parseInt(match[1], 10),
             month = parseInt(match[2], 10) - 1,
@@ -44,14 +44,13 @@ LineChatParser.prototype.process = function (line) {
     }
 
     // message
-    match = line.match(/^(\d{2}):(\d{2}) (\S.+)/);
+    match = line.match(/^(\d{2}):(\d{2})(?: |\t)(\S.+)/);
     if (match) {
         var hours = parseInt(match[1], 10),
             minutes = parseInt(match[2], 10);
         var author = "";
         this.users.forEach(function (user) {
-            var prefix = user + " ";
-            if (user.length > author.length && match[3].indexOf(prefix) === 0) {
+            if (user.length > author.length && match[3].indexOf(user) === 0) {
                 author = user;
             }
         });

--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ LineChatParser.prototype.process = function (line) {
     var match;
 
     // date header
-    match = line.match(/^(\d{4})(?:\.|\/)(\d{2})(?:\.|\/)(\d{2})(?: [A-Z][a-z]+|\(.\))/);
+    match = line.match(/^(\d{4})(?:\.|\/)(\d{2})(?:\.|\/)(\d{2})(?: [A-Z][a-z]+|\(.+\))/);
     if (match) {
         var year = parseInt(match[1], 10),
             month = parseInt(match[2], 10) - 1,

--- a/test/index.js
+++ b/test/index.js
@@ -31,6 +31,13 @@ describe("LineChatParser", function () {
 
         it("should process date headers (YYYY/MM/DD(dayName))", function () {
             var obj = new LineChatParser(["foo"]);
+            obj.process("2018/04/16(Mon)");
+            // month is 0-based
+            expect(obj.currentDate).to.deep.equal(new Date(2018, 3, 16));
+        });
+
+        it("should process date headers (YYYY/MM/DD(dayName)) (JP)", function () {
+            var obj = new LineChatParser(["foo"]);
             obj.process("2018/04/16(月)");
             // month is 0-based
             expect(obj.currentDate).to.deep.equal(new Date(2018, 3, 16));


### PR DESCRIPTION
Issue #1 

Date syntax will now be accepted both ways:
* YYYY.MM.DD dayName
* YYYY/MM/DD(dayName)

Also time, user and message separated by tabs is supported now.

I was not sure whether to change the version inside `package.json`. Is it needed for updating the package on npm later?